### PR TITLE
feat(auto-update): resolve Unity class, method, and fields automatically

### DIFF
--- a/src/appdata/helpers.h
+++ b/src/appdata/helpers.h
@@ -169,6 +169,29 @@ namespace app
     }
 
     /**
+     * @brief Finds the method that appears immediately before a specified method.
+     * @param klass Pointer to UnityResolve::Class.
+     * @param beforeMethodName Name of the anchor method.
+     * @return Pointer to the method that appears before it, or nullptr if not found.
+     */
+    inline UnityResolve::Method* findMethodBefore(UnityResolve::Class* klass,
+                                                  std::string_view beforeMethodName)
+    {
+        UnityResolve::Method* prev = nullptr;
+
+        for (const auto& method : klass->methods)
+        {
+            if (!method) continue;
+
+            if (method->name == beforeMethodName) return prev;
+
+            prev = method;
+        }
+
+        return nullptr;
+    }
+
+    /**
      * @brief Finds a method that appears between two known methods.
      * @param klass Unity class to search in.
      * @param afterMethodName Name of the method that comes before the target.
@@ -195,29 +218,6 @@ namespace app
             }
 
             if (name == afterMethodName) found = true;
-        }
-
-        return nullptr;
-    }
-
-    /**
-     * @brief Finds the method that appears immediately before a specified method.
-     * @param klass Pointer to UnityResolve::Class.
-     * @param beforeMethodName Name of the anchor method.
-     * @return Pointer to the method that appears before it, or nullptr if not found.
-     */
-    inline UnityResolve::Method* findMethodBefore(UnityResolve::Class* klass,
-                                                  std::string_view beforeMethodName)
-    {
-        UnityResolve::Method* prev = nullptr;
-
-        for (const auto& method : klass->methods)
-        {
-            if (!method) continue;
-
-            if (method->name == beforeMethodName) return prev;
-
-            prev = method;
         }
 
         return nullptr;

--- a/src/appdata/helpers.h
+++ b/src/appdata/helpers.h
@@ -252,4 +252,36 @@ namespace app
 
         return nullptr;
     }
+
+    inline std::pair<UnityResolve::Field*, int> getFieldFromClass(const UnityResolve::Class* klass,
+                                                                  const std::string& fieldName)
+    {
+        if (!klass)
+        {
+            LOG_ERROR("Unity class is null");
+            return {nullptr, -1};
+        }
+
+        for (const auto& field : klass->fields)
+        {
+            if (field && field->name == fieldName)
+            {
+                return {field, field->offset};
+            }
+        }
+
+        LOG_ERROR("Field '%s' not found in class '%s'", fieldName.c_str(), klass->name.c_str());
+        return {nullptr, -1};
+    }
+
+    inline int getFieldOffset(const UnityResolve::Class* klass, const std::string& fieldName)
+	{
+        if (auto [field, offset] = getFieldFromClass(klass, fieldName); field)
+		{
+			return offset;
+		}
+
+		LOG_ERROR("Failed to get offset for field '%s' in class '%s'", fieldName.c_str(), klass->name.c_str());
+		return -1;
+	}
 }

--- a/src/appdata/helpers.h
+++ b/src/appdata/helpers.h
@@ -4,6 +4,12 @@
 
 namespace app
 {
+    /**
+     * @brief Retrieves a Unity class by its module and class name.
+     * @param module The name of the Unity module (e.g., "Assembly-CSharp.dll", "mscorlib.dll"). 
+     * @param className The name of the class within that module (e.g., "PlayerController", "GameManager").
+     * @return A pointer to the UnityResolve::Class object if found, or nullptr if not found.
+     */
     inline UnityResolve::Class* getClass(const std::string& module, const std::string& className)
     {
         auto unityModule = UnityResolve::Get(module);
@@ -13,27 +19,36 @@ namespace app
             return nullptr;
         }
 
-        auto unityClass = unityModule->Get(className);
-        if (!unityClass)
+        auto klass = unityModule->Get(className);
+        if (!klass)
         {
             LOG_ERROR("Class '%s' not found in module '%s'", className.c_str(), module.c_str());
             return nullptr;
         }
 
-        return unityClass;
+        return klass;
     }
 
+
+    /**
+     * @brief Finds the method immediately after a given method in a Unity class.
+     * @param module The name of the Unity module (e.g., "Assembly-CSharp.dll", "mscorlib.dll").
+     * @param className The name of the class within that module (e.g., "PlayerController", "GameManager"). 
+     * @param methodName The name of the method (e.g., "Start", "Update").
+     * @return A pointer to the UnityResolve::Method object if found, or nullptr if not found.
+     */
     inline UnityResolve::Method* getMethod(const std::string& module,
-                                           const std::string& className, const std::string& methodName)
+                                           const std::string& className,
+                                           const std::string& methodName)
     {
-        auto unityClass = getClass(module, className);
-        if (!unityClass)
+        auto klass = getClass(module, className);
+        if (!klass)
         {
             LOG_ERROR("Failed to get class '%s' from module '%s'", className.c_str(), module.c_str());
             return nullptr;
         }
 
-        auto method = unityClass->Get<UnityResolve::Method>(methodName);
+        auto method = klass->Get<UnityResolve::Method>(methodName);
         if (!method)
         {
             LOG_ERROR("Method '%s' not found in class '%s' of module '%s'", methodName.c_str(), className.c_str(),
@@ -44,26 +59,40 @@ namespace app
         return method;
     }
 
-    inline UnityResolve::Method* getMethod(UnityResolve::Class* unityClass, const std::string& methodName)
+    /**
+     * @brief Retrieves a method from a Unity class by name.
+     * @param klass Pointer to a UnityResolve::Class object.
+     * @param methodName Name of the method to find.
+     * @return Pointer to UnityResolve::Method, or nullptr on failure.
+     */
+    inline UnityResolve::Method* getMethod(UnityResolve::Class* klass, const std::string& methodName)
     {
-        if (!unityClass)
+        if (!klass)
         {
             LOG_ERROR("Unity class is null");
             return nullptr;
         }
 
-        auto method = unityClass->Get<UnityResolve::Method>(methodName);
+        auto method = klass->Get<UnityResolve::Method>(methodName);
         if (!method)
         {
-            LOG_ERROR("Method '%s' not found in class '%s'", methodName.c_str(), unityClass->name.c_str());
+            LOG_ERROR("Method '%s' not found in class '%s'", methodName.c_str(), klass->name.c_str());
             return nullptr;
         }
 
         return method;
     }
 
+    /**
+     * @brief Gets the raw method address from module/class/method strings.
+     * @param module Module name.
+     * @param className Class name.
+     * @param methodName Method name.
+     * @return Function pointer address, or nullptr on failure.
+     */
     inline void* getMethodAddress(const std::string& module,
-                                  const std::string& className, const std::string& methodName)
+                                  const std::string& className,
+                                  const std::string& methodName)
     {
         auto method = getMethod(module, className, methodName);
         if (!method)
@@ -76,24 +105,35 @@ namespace app
         return *static_cast<void**>(method->address);
     }
 
-    inline void* getMethodAddress(UnityResolve::Class* unityClass, const std::string& methodName)
+    /**
+     * @brief Gets a raw method address from a Unity class and method name.
+     * @param klass Pointer to the Unity class.
+     * @param methodName Name of the method.
+     * @return Function pointer address, or nullptr on failure.
+     */
+    inline void* getMethodAddress(UnityResolve::Class* klass, const std::string& methodName)
     {
-        if (!unityClass)
+        if (!klass)
         {
             LOG_ERROR("Unity class is null");
             return nullptr;
         }
 
-        auto method = getMethod(unityClass, methodName);
+        auto method = getMethod(klass, methodName);
         if (!method)
         {
-            LOG_ERROR("Failed to get method '%s' from class '%s'", methodName.c_str(), unityClass->name.c_str());
+            LOG_ERROR("Failed to get method '%s' from class '%s'", methodName.c_str(), klass->name.c_str());
             return nullptr;
         }
 
         return *static_cast<void**>(method->address);
     }
 
+    /**
+     * @brief Gets the raw address of an already resolved Unity method.
+     * @param method Pointer to UnityResolve::Method.
+     * @return Raw function pointer, or nullptr if method is null.
+     */
     inline void* getMethodAddress(UnityResolve::Method* method)
     {
         if (!method)
@@ -103,5 +143,83 @@ namespace app
         }
 
         return *static_cast<void**>(method->address);
+    }
+
+    /**
+     * @brief Finds the method that appears immediately after a specified method.
+     * @param klass Pointer to UnityResolve::Class.
+     * @param afterMethodName Name of the anchor method.
+     * @return Pointer to the next method in order, or nullptr if not found.
+     */
+    inline UnityResolve::Method* findMethodAfter(UnityResolve::Class* klass,
+                                                 std::string_view afterMethodName)
+    {
+        bool found = false;
+
+        for (const auto& method : klass->methods)
+        {
+            if (!method) continue;
+
+            if (found) return method;
+
+            if (method->name == afterMethodName) found = true;
+        }
+
+        return nullptr;
+    }
+
+    /**
+     * @brief Finds a method that appears between two known methods.
+     * @param klass Unity class to search in.
+     * @param afterMethodName Name of the method that comes before the target.
+     * @param beforeMethodName Optional name of the method that should follow the target.
+     * @return The method found between the two, or nullptr on failure.
+     */
+    inline UnityResolve::Method* findMethodBetween(UnityResolve::Class* klass,
+                                                   std::string_view afterMethodName,
+                                                   std::optional<std::string_view> beforeMethodName = std::nullopt)
+    {
+        bool found = false;
+
+        for (const auto& method : klass->methods)
+        {
+            if (!method) continue;
+
+            std::string_view name = method->name;
+
+            if (found)
+            {
+                if (beforeMethodName && name == *beforeMethodName) break;
+
+                return method;
+            }
+
+            if (name == afterMethodName) found = true;
+        }
+
+        return nullptr;
+    }
+
+    /**
+     * @brief Finds the method that appears immediately before a specified method.
+     * @param klass Pointer to UnityResolve::Class.
+     * @param beforeMethodName Name of the anchor method.
+     * @return Pointer to the method that appears before it, or nullptr if not found.
+     */
+    inline UnityResolve::Method* findMethodBefore(UnityResolve::Class* klass,
+                                                  std::string_view beforeMethodName)
+    {
+        UnityResolve::Method* prev = nullptr;
+
+        for (const auto& method : klass->methods)
+        {
+            if (!method) continue;
+
+            if (method->name == beforeMethodName) return prev;
+
+            prev = method;
+        }
+
+        return nullptr;
     }
 }

--- a/src/appdata/types-helper.h
+++ b/src/appdata/types-helper.h
@@ -5,11 +5,29 @@ private:\
     inline static constexpr const char* ModuleName = MODULE; \
     inline static constexpr const char* ClassName = CLASS_NAME; \
 public: \
+    inline static const char* getClassName() { return ClassName; } \
     inline static UnityResolve::Class* getClass() { \
         static UnityResolve::Class* c = nullptr; \
         if (!c) c = app::getClass(MODULE, CLASS_NAME); \
         return c; \
 	}
+
+#define UNITY_CLASS_DECL_FROM_FIELD_NAME(MODULE, CONTAINER_CLASS_NAME, FIELD_NAME) \
+private: \
+    inline static constexpr const char* ModuleName = MODULE; \
+    inline static constexpr const char* ContainerClassName = CONTAINER_CLASS_NAME; \
+    inline static constexpr const char* FieldName = FIELD_NAME; \
+    inline static const char* ClassName; \
+public: \
+    inline static const char* getClassName() { return ClassName; } \
+    inline static UnityResolve::Class* getClass() { \
+        static UnityResolve::Class* cachedClass = nullptr; \
+        if (!cachedClass) { \
+            cachedClass = app::findClassFromField(ModuleName, ContainerClassName, FieldName); \
+            ClassName = cachedClass ? cachedClass->name.c_str() : ""; \
+        } \
+        return cachedClass; \
+    }
 
 #define UNITY_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_OFFSET) \
     inline FIELD_TYPE FIELD_NAME() { \

--- a/src/appdata/types-helper.h
+++ b/src/appdata/types-helper.h
@@ -1,10 +1,10 @@
 ﻿#pragma once
 
 #define UNITY_CLASS_DECL(MODULE, CLASS_NAME) \
-    private:\
+private:\
     inline static constexpr const char* ModuleName = MODULE; \
     inline static constexpr const char* ClassName = CLASS_NAME; \
-    public: \
+public: \
     inline static UnityResolve::Class* getClass() { \
         static UnityResolve::Class* c = nullptr; \
         if (!c) c = app::getClass(MODULE, CLASS_NAME); \
@@ -21,10 +21,10 @@
 
 // Used to initialize a method pointer for a class that's declared with UNITY_CLASS_DECL
 #define UNITY_METHOD(RETURN_TYPE, METHOD_NAME, ...) \
-    private: \
+private: \
     inline static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> METHOD_NAME##_ptr{}; \
     inline static bool METHOD_NAME##_initialized = false; \
-    public: \
+public: \
     inline static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> METHOD_NAME() { \
         if (!METHOD_NAME##_initialized) { \
             auto method = app::getMethod(ModuleName, ClassName, #METHOD_NAME); \
@@ -36,19 +36,58 @@
         return METHOD_NAME##_ptr; \
     }
 
-// Lazy initialization macro for methods from a specific module
-#define UNITY_METHOD_FROM(MODULE, CLASS_NAME, RETURN_TYPE, METHOD_NAME, ...) \
+// Resolves a method that comes AFTER a known method in the same class
+#define UNITY_METHOD_AFTER(RETURN_TYPE, METHOD_NAME, AFTER_NAME, ...) \
+private: \
+    inline static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> METHOD_NAME##_ptr{}; \
+    inline static bool METHOD_NAME##_initialized = false; \
+public: \
     inline static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> METHOD_NAME() { \
-        static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> cached_method{}; \
-        static bool initialized = false; \
-        if (!initialized) { \
-            auto method = app::getMethod(MODULE, CLASS_NAME, #METHOD_NAME); \
+        if (!METHOD_NAME##_initialized) { \
+            auto cls = getClass(); \
+            auto method = app::findMethodAfter(cls, AFTER_NAME); \
             if (method) { \
-                cached_method = method->Cast<RETURN_TYPE, __VA_ARGS__>(); \
+                METHOD_NAME##_ptr = method->Cast<RETURN_TYPE, __VA_ARGS__>(); \
             } \
-            initialized = true; \
+            METHOD_NAME##_initialized = true; \
         } \
-        return cached_method; \
+        return METHOD_NAME##_ptr; \
+    }
+
+// Resolves a method that comes BEFORE a known method in the same class
+#define UNITY_METHOD_BEFORE(RETURN_TYPE, METHOD_NAME, BEFORE_NAME, ...) \
+private: \
+    inline static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> METHOD_NAME##_ptr{}; \
+    inline static bool METHOD_NAME##_initialized = false; \
+public: \
+    inline static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> METHOD_NAME() { \
+        if (!METHOD_NAME##_initialized) { \
+            auto cls = getClass(); \
+            auto method = app::findMethodBefore(cls, BEFORE_NAME); \
+            if (method) { \
+                METHOD_NAME##_ptr = method->Cast<RETURN_TYPE, __VA_ARGS__>(); \
+            } \
+            METHOD_NAME##_initialized = true; \
+        } \
+        return METHOD_NAME##_ptr; \
+    }
+
+// Resolves a method BETWEEN two known method names in the same class
+#define UNITY_METHOD_BETWEEN(RETURN_TYPE, METHOD_NAME, AFTER_NAME, BEFORE_NAME, ...) \
+private: \
+    inline static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> METHOD_NAME##_ptr{}; \
+    inline static bool METHOD_NAME##_initialized = false; \
+public: \
+    inline static UnityResolve::MethodPointer<RETURN_TYPE, __VA_ARGS__> METHOD_NAME() { \
+        if (!METHOD_NAME##_initialized) { \
+            auto cls = getClass(); \
+            auto method = app::findMethodBetween(cls, AFTER_NAME, BEFORE_NAME); \
+            if (method) { \
+                METHOD_NAME##_ptr = method->Cast<RETURN_TYPE, __VA_ARGS__>(); \
+            } \
+            METHOD_NAME##_initialized = true; \
+        } \
+        return METHOD_NAME##_ptr; \
     }
 
 // Alternatively, you can call METHOD()(arguments) directly. But it doesn't look as nice.

--- a/src/appdata/types.h
+++ b/src/appdata/types.h
@@ -167,8 +167,7 @@ public:
 
     UNITY_METHOD(void, Update, Battle*)
     UNITY_METHOD(void, Begin, Battle*)
-    // TODO CRITICAL!!: since this is obfuscated, need to implement a fallback using signatures or some sort of way
-    UNITY_METHOD(void, O41c95fd17e6626c6f1f7aa3c0ef0fd3c9d8ca5ea99daee82eee4c511efa52952, Battle*, BattleEndType_Enum)
+    UNITY_METHOD_BETWEEN(void, Finalize, "Resume", "Push", Battle*, BattleEndType_Enum)
 };
 
 class CharacterGroup

--- a/src/appdata/types.h
+++ b/src/appdata/types.h
@@ -46,7 +46,9 @@ public:
 class PlayerSkillCardManager : public CostSkillCardManager
 {
 public:
-    UNITY_METHOD_FROM("BlueArchive.dll", "PlayerSkillCardManager", void, ProcessSkillCard, PlayerSkillCardManager*)
+    UNITY_CLASS_DECL("BlueArchive.dll", "PlayerSkillCardManager")
+
+    UNITY_METHOD(void, ProcessSkillCard, PlayerSkillCardManager*)
 };
 
 class BattleEntityStat
@@ -163,7 +165,6 @@ public:
     UNITY_FIELD(int, TotalEnemyCount, 0x2F8)
     UNITY_FIELD(int, RemainEnemyCount, 0x2FC)
 
-
     UNITY_METHOD(void, Update, Battle*)
     UNITY_METHOD(void, Begin, Battle*)
     // TODO CRITICAL!!: since this is obfuscated, need to implement a fallback using signatures or some sort of way
@@ -263,7 +264,6 @@ public:
     UNITY_FIELD(int64_t, AIPhaseToChange, 0x430)
     UNITY_FIELD(int64_t, currentActiveGauge, 0x440)
     UNITY_FIELD(int32_t, CurrentNormalAttackCount, 0x448)
-
 
     UNITY_METHOD(void, Update, Character*, Battle*)
     UNITY_METHOD(void, InitAmmo, Character*)

--- a/src/appdata/types.h
+++ b/src/appdata/types.h
@@ -30,7 +30,6 @@ class NewNormalAttackAction;
 
 class CostSkillCardManager
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "CostSkillCardManager")
 
     UNITY_FIELD(float, MaxCost, 0x38)
@@ -45,7 +44,6 @@ public:
 
 class PlayerSkillCardManager : public CostSkillCardManager
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "PlayerSkillCardManager")
 
     UNITY_METHOD(void, ProcessSkillCard, PlayerSkillCardManager*)
@@ -53,7 +51,6 @@ public:
 
 class BattleEntityStat
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "BattleEntityStat")
 
     UNITY_METHOD(int64_t, get_Item, BattleEntityStat*, StatType_Enum)
@@ -61,7 +58,6 @@ public:
 
 class BattleEntityStatProcessor
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "BattleEntityStatProcessor")
 
     UNITY_FIELD(int64_t, BattlePower, 0x10)
@@ -76,7 +72,6 @@ public:
 
 class BattleEntity
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "BattleEntity")
 
     UNITY_FIELD(void*, Damaged, 0x28) // EventHandler<BattleEntityDamagedEventArgs>
@@ -88,8 +83,7 @@ public:
     UNITY_FIELD(int64_t, SummonedTime, 0x90)
     UNITY_FIELD(ArmorType_Enum, ArmorType, 0x98)
     UNITY_FIELD(BattleEntityStatProcessor*, statProcessor, 0xA0)
-
-
+    
     // UNITY_METHOD(void, OnDamaged, BattleEntity*, void*)
     UNITY_METHOD(bool, CanBeTargeted, BattleEntity*, BattleEntity*, SkillSlot_Enum)
     UNITY_METHOD(int64_t, AddHitPoint, BattleEntity*, int64_t)
@@ -99,7 +93,6 @@ public:
 
 class BattleSummary
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "BattleSummary")
 
     UNITY_FIELD(int64_t, HashKey, 0x10)
@@ -132,7 +125,6 @@ struct TimeSpan
 
 class LogicGameTime
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "LogicGameTime")
 
     UNITY_FIELD(float, UnitySecondPerFrame, 0x10)
@@ -150,7 +142,6 @@ public:
 
 class Battle
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "Battle")
 
     UNITY_FIELD(BattleLogicState_Enum, state, 0x188)
@@ -203,8 +194,7 @@ public:
 // Obfuscated class
 class Character : public BattleEntity
 {
-public:
-    UNITY_CLASS_DECL("BlueArchive.dll", "Oa5c503f80e3a6fabdca83cda0af9e61bf1cdfa15fe0a322f74c82f8f819ca6e6")
+    UNITY_CLASS_DECL_FROM_FIELD_NAME("BlueArchive.dll", "CharacterMovementComponent", "<Character>k__BackingField")
 
     UNITY_FIELD(bool, IsSearchAndMoveActivated, 0x118)
     UNITY_FIELD(int32_t, lastTargetFindFrame, 0x11C)
@@ -318,7 +308,6 @@ class NewSkillAction : public HeroAction
 
 class NewNormalAttackAction : public NewSkillAction
 {
-public:
     UNITY_CLASS_DECL("BlueArchive.dll", "NewNormalAttackAction")
 
     UNITY_FIELD(Character*, ownerCharacter, 0x178)

--- a/src/appdata/types.h
+++ b/src/appdata/types.h
@@ -83,7 +83,7 @@ class BattleEntity
     UNITY_FIELD(int64_t, SummonedTime, 0x90)
     UNITY_FIELD(ArmorType_Enum, ArmorType, 0x98)
     UNITY_FIELD(BattleEntityStatProcessor*, statProcessor, 0xA0)
-    
+
     // UNITY_METHOD(void, OnDamaged, BattleEntity*, void*)
     UNITY_METHOD(bool, CanBeTargeted, BattleEntity*, BattleEntity*, SkillSlot_Enum)
     UNITY_METHOD(int64_t, AddHitPoint, BattleEntity*, int64_t)
@@ -140,6 +140,46 @@ class LogicGameTime
     UNITY_METHOD(void, Resume, LogicGameTime*)
 };
 
+class LogicEffect
+{
+    UNITY_CLASS_DECL("BlueArchive.dll", "LogicEffect")
+
+    // UNITY_FIELD(SkillSpecification*, SkillSpecification, 0x10)
+    // UNITY_FIELD(LogicEffectHitSpecification*, LogicEffectHitSpecification, 0x18)
+    // UNITY_FIELD(BattleEntity*, Invoker, 0x20)
+    // UNITY_FIELD(BattleEntity*, Target, 0x28)
+    // UNITY_FIELD(BattleEntity*, OriginalTarget, 0x30)
+    // UNITY_FIELD(Func_1_Boolean_*, ExpirationCheck, 0x38)
+    // UNITY_FIELD(Entity*, ExpirationCheckOwner, 0x40)
+    // UNITY_FIELD(String*, SkillEntityName, 0x48)
+    // UNITY_FIELD(int64_t, SpawnRate, 0x50)
+    // UNITY_FIELD(String*, LogicEffectGroupId, 0x58)
+    // UNITY_FIELD(LogicEffectCategory__Enum, Category, 0x60)
+    // UNITY_FIELD(String*, templateId, 0x68)
+    // UNITY_FIELD(Hash64, TemplateIdHash, 0x70)
+    // UNITY_FIELD(int32_t, Channel, 0x78)
+    // UNITY_FIELD(BasisPoint, ApplyRate, 0x80)
+    // UNITY_FIELD(uint32_t, CommonVisualIdHash, 0x88)
+    // UNITY_FIELD(Vector2, HitPosition, 0x8C)
+    // UNITY_FIELD(Vector2, BulletPosition, 0x94)
+    // UNITY_FIELD(Vector2, BulletDirection, 0x9C)
+    // UNITY_FIELD(Entity*, BulletEntity, 0xA8)
+    // UNITY_FIELD(ResolvePriority__Enum, priority, 0xB0)
+    // UNITY_FIELD(int32_t, Priority, 0xB4)
+    // UNITY_FIELD(int32_t, ResolveIndex, 0xB8)
+    // UNITY_FIELD(int32_t, DotIndex, 0xBC)
+    // UNITY_FIELD(int32_t, ExtraCostUsed, 0xC0)
+    // UNITY_FIELD(bool, ForceFloaterHide, 0xC4)
+};
+
+// Obfuscated class
+class LogicEffectProcessor
+{
+    UNITY_CLASS_DECL_FROM_FIELD_NAME("BlueArchive.dll", "CrowdControlGaugeEffect", "logicEffectProcessor")
+
+    UNITY_FIELD(UnityResolve::UnityType::List<LogicEffect>*, logicEffects, 0x48)
+};
+
 class Battle
 {
     UNITY_CLASS_DECL("BlueArchive.dll", "Battle")
@@ -148,7 +188,7 @@ class Battle
     UNITY_FIELD(LogicGameTime*, GameTime, 0x190)
     UNITY_FIELD(int64_t, StartTickRealTime, 0x198)
     UNITY_FIELD(int, MaxDurationFrame, 0x1A0)
-    // UNITY_FIELD(O139cb8484a6efbeade5b8c6d40e89e4aec30556aa791f82dc4247b81d8d0d42d, LogicEffectProcessor, 0x1D8)
+    UNITY_FIELD(LogicEffectProcessor*, LogicEffectProcessor_, 0x1D8)
     UNITY_FIELD(BattleSummary*, BattleSummary_, 0x1F0)
     UNITY_FIELD(double, UnitType, 0x200)
     UNITY_FIELD(double, ResultValue, 0x208)
@@ -168,14 +208,12 @@ class CharacterGroup
 
 class PlayerGroup : public CharacterGroup
 {
-public:
     UNITY_FIELD(int, EchelonNumber, 0x140)
     UNITY_FIELD(PlayerSkillCardManager*, PlayerSkillCardManager_, 0x150)
 };
 
 class ShieldEffect
 {
-public:
     UNITY_FIELD(int64_t, BaseAmount, 0xC8)
     UNITY_FIELD(StatType_Enum, TargetStatType, 0xD0)
     UNITY_FIELD(StatType_Enum, CasterStatType, 0xE0)
@@ -185,7 +223,6 @@ public:
 
 class ShieldInfo
 {
-public:
     UNITY_FIELD(int64_t, CurrentHP_k, 0x10)
     UNITY_FIELD(int64_t, MaxHP_k, 0x18)
     UNITY_FIELD(ShieldEffect, ShieldEffect_k, 0x28)
@@ -262,7 +299,6 @@ class Character : public BattleEntity
 
 class DamageResult
 {
-public:
     UNITY_FIELD(int64_t, AttackPower, 0x00)
     UNITY_FIELD(int64_t, Damage, 0x08)
     UNITY_FIELD(int32_t, Stability, 0x10)

--- a/src/user/cheat/features/game/InstantWin.cpp
+++ b/src/user/cheat/features/game/InstantWin.cpp
@@ -18,8 +18,7 @@ namespace cheat::features
             _this->BattleSummary_()->EndFrame(0);
             _this->BattleSummary_()->ElapsedRealtime(0.f);
 
-            UNITY_CALL(Battle::O41c95fd17e6626c6f1f7aa3c0ef0fd3c9d8ca5ea99daee82eee4c511efa52952,
-                       _this, BattleEndType_Enum::Clear)
+            UNITY_CALL(Battle::Finalize, _this, BattleEndType_Enum::Clear)
         }
 
         CALL_ORIGINAL(hBattle_Update, _this);

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -26,6 +26,13 @@ void Main::run()
     }
 
     cheat::init();
+
+    auto battleClass = app::getClass("BlueArchive.dll", "Battle");
+    auto fAfter = app::findMethodAfter(battleClass, "Resume");
+    auto fBetween = app::findMethodBetween(battleClass, "Resume", "Push");
+    auto fBefore = app::findMethodBefore(battleClass, "Push");
+    LOG_DEBUG("fAfter %p, fBetween %p, fBefore %p",
+			  app::getMethodAddress(fAfter), app::getMethodAddress(fBetween), app::getMethodAddress(fBefore));
 }
 
 UnityModuleBackendInfo Main::getUnityBackend()

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -27,12 +27,12 @@ void Main::run()
 
     cheat::init();
 
-    auto battleClass = app::getClass("BlueArchive.dll", "Battle");
-    auto fAfter = app::findMethodAfter(battleClass, "Resume");
-    auto fBetween = app::findMethodBetween(battleClass, "Resume", "Push");
-    auto fBefore = app::findMethodBefore(battleClass, "Push");
-    LOG_DEBUG("fAfter %p, fBetween %p, fBefore %p",
-			  app::getMethodAddress(fAfter), app::getMethodAddress(fBetween), app::getMethodAddress(fBefore));
+    auto characterClass = app::findClassFromField("BlueArchive.dll", "CharacterMovementComponent", "<Character>k__BackingField");
+    auto update = app::getMethodAddress(characterClass, "Update");
+    if (update)
+    {
+        LOG_DEBUG("Found Update method in Character class: %p", update);
+    }
 }
 
 UnityModuleBackendInfo Main::getUnityBackend()

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -26,13 +26,6 @@ void Main::run()
     }
 
     cheat::init();
-
-    auto characterClass = app::findClassFromField("BlueArchive.dll", "CharacterMovementComponent", "<Character>k__BackingField");
-    auto update = app::getMethodAddress(characterClass, "Update");
-    if (update)
-    {
-        LOG_DEBUG("Found Update method in Character class: %p", update);
-    }
 }
 
 UnityModuleBackendInfo Main::getUnityBackend()


### PR DESCRIPTION
<h1>📝 Description</h1>
Since we're dealing with obfuscated class, methods or fields, resolving members by name alone becomes unreliable as these names change every patch. Yes, we can use PattternScan as an alternative, but that can also break at any time.

This will allow auto-update or a enabling almost zero maintenance updates for affected features.


<h1>✔️ Features Added</h1>

- [x] `findMethodAfter`: Resolve after known method
- [x] `findMethodBetween`: Resolve between known methods
- [x] `findMethodBefore`: Resolve before known method
- [x] `UNITY_METHOD_AFTER`: macro for method declaration
- [x] `UNITY_METHOD_BEFORE`: macro for method declaration
- [x] `UNITY_METHOD_BETWEEN`: macro for method declaration
- [x] `findClassFromField`: Resolves the UnityClass* based on known Class and Fields (e.g, `CharacterComponent` class has field `<Character>k__BackingField`. We wanna return the type of that field
- [x] `UNITY_CLASS_DECL_FROM_FIELD_NAME` macro for class declaration
- [x] `getFieldFromClass`: Returns the Field* and offset(int) of a given Class* and fieldName
- [x] `getFieldOffset`: Returns the field offset of given Unity* and fieldName
- [x] `UNITY_FIELD_FROM`: macro for field declaraction from actual fieldName